### PR TITLE
Design: 메인페이지 캐러셀 너비 지정 / Fix: 모임 컴포넌트 genderRange 변환

### DIFF
--- a/app/(withHeader)/page.tsx
+++ b/app/(withHeader)/page.tsx
@@ -54,17 +54,19 @@ const TeamThumbnailContainer = styled.div`
   width: 100%;
   grid-template-columns: repeat(2, 1fr);
   grid-template-rows: repeat(3, auto);
-  gap: 1.44rem;
+  gap: 2.19rem;
   padding-bottom: 7.5rem;
 
   @media (max-width: 768px) {
     grid-template-columns: repeat(1, 1fr);
     grid-template-rows: repeat(3, auto);
+    gap: 1.875rem;
   }
 
   @media (max-width: 480px) {
     grid-template-columns: repeat(1, 1fr);
     grid-template-rows: repeat(4, auto);
+    gap: 0.9375rem;
   }
 `;
 

--- a/src/components/main/CarouselSection.tsx
+++ b/src/components/main/CarouselSection.tsx
@@ -3,13 +3,23 @@
 import { Carousel } from 'antd';
 import styled from 'styled-components';
 
-const contentStyle: React.CSSProperties = {
-  margin: 0,
-  color: '#fff',
-  lineHeight: '160px',
-  textAlign: 'center',
-  background: '#40A9FF',
-};
+const StyledSlideContent = styled.h3`
+  margin: 0;
+  color: #fff;
+  line-height: 160px;
+  text-align: center;
+  background: #40a9ff;
+  width: 100%;
+  height: 25.125rem;
+
+  @media (max-width: 768px) {
+    height: 16.1875rem;
+  }
+
+  @media (max-width: 480px) {
+    height: 10.5rem;
+  }
+`;
 
 const CarouselContainer = styled.div`
   width: 100%;
@@ -25,16 +35,16 @@ export default function CarouselSection() {
     <CarouselContainer>
       <Carousel afterChange={onChange}>
         <div>
-          <h3 style={contentStyle}>1</h3>
+          <StyledSlideContent>1</StyledSlideContent>
         </div>
         <div>
-          <h3 style={contentStyle}>2</h3>
+          <StyledSlideContent>2</StyledSlideContent>
         </div>
         <div>
-          <h3 style={contentStyle}>3</h3>
+          <StyledSlideContent>3</StyledSlideContent>
         </div>
         <div>
-          <h3 style={contentStyle}>4</h3>
+          <StyledSlideContent>4</StyledSlideContent>
         </div>
       </Carousel>
     </CarouselContainer>

--- a/src/components/main/NavButton.tsx
+++ b/src/components/main/NavButton.tsx
@@ -13,13 +13,15 @@ interface NavButtonProps {
 const NavButtonContainer = styled.div`
   display: flex;
   flex-direction: column;
-  flex: 1 0 0;
   padding: 0.625rem 3.0625rem;
   justify-content: center;
   align-items: center;
   gap: 0.625rem;
-  border-radius: 0.1875rem;
+  flex: 1 0 0;
+  align-self: stretch;
+  border-radius: 0.625rem;
   background: ${colors.Grayscale[3]};
+  color: ${colors.Grayscale[13]};
   text-align: center;
   ${typography.Heading16};
 

--- a/src/components/shared/TeamThumbnail.tsx
+++ b/src/components/shared/TeamThumbnail.tsx
@@ -73,19 +73,7 @@ const TeamChips = styled.div`
   flex-shrink: 0;
 `;
 
-const GenderRange = styled.div`
-  display: flex;
-  padding: 0.1875rem 0.4375rem;
-  justify-content: center;
-  align-items: center;
-  border-radius: 0.1875rem;
-  background: ${colors.Primary[50]};
-  color: ${colors.Primary[500]};
-  text-align: center;
-  ${typography.Footnote14};
-`;
-
-const AgeRange = styled.div`
+const TeamRange = styled.div`
   display: flex;
   padding: 0.1875rem 0.4375rem;
   justify-content: center;
@@ -171,12 +159,12 @@ export default function TeamThumbnail({ team }: { team: TeamFeedType }) {
           <p>{`${team.exploreId} | ${formattedDate} | ${formattedTime}`}</p>
         </TeamInfo>
         <TeamChips>
-          <GenderRange>
+          <TeamRange>
             <p>{renderGenderText()}</p>
-          </GenderRange>
-          <AgeRange>
+          </TeamRange>
+          <TeamRange>
             <p>{renderAgeRangeText()}</p>
-          </AgeRange>
+          </TeamRange>
         </TeamChips>
       </TeamCol>
     </TeamBox>

--- a/src/components/shared/TeamThumbnail.tsx
+++ b/src/components/shared/TeamThumbnail.tsx
@@ -91,8 +91,8 @@ const AgeRange = styled.div`
   justify-content: center;
   align-items: center;
   border-radius: 0.1875rem;
-  background: ${colors.System[`Warning_bg`]};
-  color: ${colors.System[`Warning`]};
+  background: ${colors.Primary[50]};
+  color: ${colors.Primary[500]};
   text-align: center;
   ${typography.Footnote14};
 `;
@@ -103,7 +103,7 @@ interface TeamFeedType {
   title: string;
   departureDay: string;
   ageRange: string[];
-  genderRange: string[];
+  genderRange: string;
 }
 
 // 클릭 시 상세페이지로 이동하는 기능 추가, 산 아이디에 따른 이름 변환 필요
@@ -125,20 +125,17 @@ export default function TeamThumbnail({ team }: { team: TeamFeedType }) {
   const { formattedDate, formattedTime } = formatDate(team.departureDay);
 
   const renderGenderText = () => {
-    const genderRanges = Array.isArray(team.genderRange)
-      ? team.genderRange
-      : [team.genderRange];
-
-    if (genderRanges.includes('male') && genderRanges.includes('female')) {
-      return '성별무관';
-    } else if (genderRanges.includes('male')) {
-      return '남성만';
-    } else if (genderRanges.includes('female')) {
-      return '여성만';
+    switch (team.genderRange) {
+      case 'male':
+        return '남성만';
+      case 'female':
+        return '여성만';
+      case 'all':
+        return '성별무관';
+      default:
+        return '';
     }
-    return ''; // genderRange가 빈 문자열이거나 빈 배열인 경우
   };
-
   const renderAgeRangeText = () => {
     const ageRanges = Array.isArray(team.ageRange)
       ? team.ageRange

--- a/src/lib/mockData.ts
+++ b/src/lib/mockData.ts
@@ -5,7 +5,7 @@ export const teamFeed = [
     title: '관악산 함께가요',
     departureDay: '2024-04-08 14:00',
     ageRange: ['teenager'],
-    genderRange: ['male', 'female'],
+    genderRange: 'all',
   },
   {
     teamId: 2,
@@ -13,7 +13,7 @@ export const teamFeed = [
     title: '북한산 가보자고',
     departureDay: '2024-10-05 11:00',
     ageRange: ['twenties', 'thirties'],
-    genderRange: ['male'],
+    genderRange: 'male',
   },
   {
     teamId: 3,
@@ -21,7 +21,7 @@ export const teamFeed = [
     title: '명지산 렛츠고',
     departureDay: '2024-09-12 13:00',
     ageRange: ['fifties'],
-    genderRange: ['male', 'female'],
+    genderRange: 'all',
   },
   {
     teamId: 4,
@@ -29,7 +29,7 @@ export const teamFeed = [
     title: '고수만 모십니다',
     departureDay: '2024-04-16 14:00',
     ageRange: ['fourties'],
-    genderRange: ['male'],
+    genderRange: 'male',
   },
   {
     teamId: 5,
@@ -37,7 +37,7 @@ export const teamFeed = [
     title: '백운산 같이가요',
     departureDay: '2024-06-15 17:00',
     ageRange: ['twenties'],
-    genderRange: ['female'],
+    genderRange: 'female',
   },
   {
     teamId: 6,
@@ -45,6 +45,6 @@ export const teamFeed = [
     title: '용문산으로 떠나요',
     departureDay: '2024-03-27 17:00',
     ageRange: ['fifties', 'sixties'],
-    genderRange: ['female'],
+    genderRange: 'female',
   },
 ];


### PR DESCRIPTION
📌 작업 사항
--- 

- [ ] 기능 추가
- [x] 리팩토링
- [x] 스타일 수정
- [ ] 에러, 버그 수정
- [ ] 변수명, 함수명, 파일명 변경
- [ ] 폴더, 파일 구조 변경

📌 이슈
--- 

📌 작업 내용
--- 

메인페이지의 캐러셀 너비를 반응형에 맞게 지정했습니다.
또한 모임 컴포넌트를 연령대 정보 입력값 변화에 맞게 수정하고 변경된 디자인을 반영했습니다. 
추후 exploreId를 통해 산 이름을 표시하는 로직만 변경하면 될 것 같습니다.

검색바 컴포넌트가 완성되고 PR을 올리려고 했는데
모임 컴포넌트를 사용하셔야할 것 같아 PR 올립니다.
추후 main 페이지 내 수정하여 반영하겠습니다. 

📌 테스트결과 / 스크린샷 (선택)
--- 
