### PR TITLE
Feat: 검색한 산 지도에 고배율로 나타나고 검색결과에도 표시 되도록 구현, 검색 결과 쿼리 스트링에 반영되도록 구현

### DIFF
--- a/app/(withoutHeader)/signin/page.tsx
+++ b/app/(withoutHeader)/signin/page.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export default function signin() {
   return <div>signin</div>;
 }

--- a/app/teams/[teamId]/page.tsx
+++ b/app/teams/[teamId]/page.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function page() {
-  return <div>page</div>;
-}

--- a/app/teams/[teamId]/review/page.tsx
+++ b/app/teams/[teamId]/review/page.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function page() {
-  return <div>/team/teamId/review</div>;
-}

--- a/app/teams/create/page.tsx
+++ b/app/teams/create/page.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function create() {
-  return <div>create</div>;
-}

--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function team() {
-  return <div>team</div>;
-}

--- a/app/teams/write/page.tsx
+++ b/app/teams/write/page.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function write() {
-  return <div>write</div>;
-}

--- a/src/components/explore/ExploreFilterPanel.tsx
+++ b/src/components/explore/ExploreFilterPanel.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import type { CheckboxChangeEvent } from 'antd/lib/checkbox';
 import { Checkbox, Collapse } from 'antd';
 import styled from 'styled-components';
+import RegionFilter from './RegionFilter';
+import HeightFilter from './HeightFilter';
 
 const FilterHeader = styled.div`
   display: flex;
@@ -76,58 +78,13 @@ const CheckboxGroupContainer = styled.div`
   }
 `;
 
-const regionOptions = [
-  '서울',
-  '경기도',
-  '강원도',
-  '충청북도',
-  '충청남도',
-  '전라북도',
-  '전라남도',
-  '경상북도',
-  '경상남도',
-  '제주도',
-];
-
-const heightOptions = [
-  '500m 미만',
-  '500 ~ 1000m',
-  '1000 ~ 1500m',
-  '1500m 이상',
-];
-
 export default function ExploreFilterPanel() {
   const [regionCheckedList, setRegionCheckedList] = useState<string[]>([]);
   const [heightCheckedList, setHeightCheckedList] = useState<string[]>([]);
 
-  const handleCheckboxListChange = (
-    option: string,
-    checkedList: string[],
-    setCheckedList: (list: string[]) => void,
-  ) => {
-    const currentIndex = checkedList.indexOf(option);
-    const newCheckedList = [...checkedList];
-
-    if (currentIndex === -1) {
-      newCheckedList.push(option);
-    } else {
-      newCheckedList.splice(currentIndex, 1);
-    }
-
-    setCheckedList(newCheckedList);
-  };
-
   const handleCheckReset = () => {
     setRegionCheckedList([]);
     setHeightCheckedList([]);
-  };
-
-  const handleCheckAllChange = (
-    e: CheckboxChangeEvent,
-    option: string[],
-    setCheckedList: (list: string[]) => void,
-  ) => {
-    setCheckedList(e.target.checked ? option : []);
   };
 
   return (
@@ -157,74 +114,20 @@ export default function ExploreFilterPanel() {
                 key: '1',
                 label: '관심지역',
                 children: (
-                  <>
-                    <Checkbox
-                      onChange={(e) =>
-                        handleCheckAllChange(
-                          e,
-                          regionOptions,
-                          setRegionCheckedList,
-                        )
-                      }
-                      checked={
-                        regionCheckedList.length === regionOptions.length
-                      }
-                    >
-                      전체 선택
-                    </Checkbox>
-                    {regionOptions.map((option) => (
-                      <Checkbox
-                        key={option}
-                        onChange={() =>
-                          handleCheckboxListChange(
-                            option,
-                            regionCheckedList,
-                            setRegionCheckedList,
-                          )
-                        }
-                        checked={regionCheckedList.includes(option)}
-                      >
-                        {option}
-                      </Checkbox>
-                    ))}
-                  </>
+                  <RegionFilter
+                    regionCheckedList={regionCheckedList}
+                    setRegionCheckedList={setRegionCheckedList}
+                  />
                 ),
               },
               {
                 key: '2',
                 label: '높이',
                 children: (
-                  <>
-                    <Checkbox
-                      onChange={(e) =>
-                        handleCheckAllChange(
-                          e,
-                          heightOptions,
-                          setHeightCheckedList,
-                        )
-                      }
-                      checked={
-                        heightCheckedList.length === heightOptions.length
-                      }
-                    >
-                      전체 선택
-                    </Checkbox>
-                    {heightOptions.map((option) => (
-                      <Checkbox
-                        key={option}
-                        onChange={() =>
-                          handleCheckboxListChange(
-                            option,
-                            heightCheckedList,
-                            setHeightCheckedList,
-                          )
-                        }
-                        checked={heightCheckedList.includes(option)}
-                      >
-                        {option}
-                      </Checkbox>
-                    ))}
-                  </>
+                  <HeightFilter
+                    heightCheckedList={heightCheckedList}
+                    setHeightCheckedList={setHeightCheckedList}
+                  />
                 ),
               },
             ]}

--- a/src/components/explore/ExplorePage.tsx
+++ b/src/components/explore/ExplorePage.tsx
@@ -201,9 +201,7 @@ export default function ExplorePage() {
               <Input.Search
                 placeholder="대한민국 산 탐험하기"
                 enterButton
-                onSearch={() => {
-                  console.log('클릭');
-                }}
+                onSearch={handleSelectMountain}
               />
             </AutoComplete>
           </SearchContainer>

--- a/src/components/explore/ExplorePage.tsx
+++ b/src/components/explore/ExplorePage.tsx
@@ -6,7 +6,6 @@ import KakaoMap from '@/src/components/explore/KakaoMap';
 import MountainInfo from '@/src/components/shared/MountainInfo';
 import ExploreFilterPanel from '@/src/components/explore/ExploreFilterPanel';
 import getMountainData from '@/src/components/explore/getMountainData';
-import { SearchBar } from '../shared/SearchBar';
 import { AutoComplete, Input } from 'antd';
 const SearchMountainArea = styled.div`
   margin-top: 7rem;
@@ -224,10 +223,15 @@ export default function ExplorePage() {
             <MountainListHeader>
               <span>가나다순</span> <span>인기순</span>
             </MountainListHeader>
+
             <MountainList>
-              {mountainList?.map((list: any) => (
-                <MountainInfo key={list.X좌표} list={list} />
-              ))}
+              {selectedMountain ? (
+                <MountainInfo list={selectedMountain} />
+              ) : (
+                mountainList?.map((list: any) => (
+                  <MountainInfo key={list.X좌표} list={list} />
+                ))
+              )}
             </MountainList>
           </MountainListContainer>
         </SearchResultArea>

--- a/src/components/explore/ExplorePage.tsx
+++ b/src/components/explore/ExplorePage.tsx
@@ -1,13 +1,13 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import Link from 'next/link';
 import styled from 'styled-components';
 import KakaoMap from '@/src/components/explore/KakaoMap';
 import MountainInfo from '@/src/components/shared/MountainInfo';
 import ExploreFilterPanel from '@/src/components/explore/ExploreFilterPanel';
 import getMountainData from '@/src/components/explore/getMountainData';
-
+import { SearchBar } from '../shared/SearchBar';
+import { AutoComplete, Input } from 'antd';
 const SearchMountainArea = styled.div`
   margin-top: 7rem;
 `;
@@ -152,32 +152,31 @@ const AutoSearchData = styled.li`
 
 export default function ExplorePage() {
   const [keyword, setKeyword] = useState<string>('');
-  const [keyItems, setKeyItems] = useState<string[]>([]);
+  const [selectedMountain, setSelectedMountain] = useState(null);
 
   const { data: mountainList } = useQuery({
     queryKey: ['mountainList'],
     queryFn: () => getMountainData(),
   });
 
-  const handleInputChange = (e: React.FormEvent<HTMLInputElement>) => {
-    setKeyword(e.currentTarget.value);
+  const handleInputChange = (value: string) => {
+    setKeyword(value);
   };
 
-  const searchData = async () => {
-    let autoCompletedData = mountainList.filter(
-      (list: any) => list.명산_이름.includes(keyword) === true,
-    );
-    setKeyItems(autoCompletedData);
+  const options = mountainList?.map((list: any) => ({
+    value: list.명산_이름,
+  }));
+
+  const handleSelectMountain = (value: string) => {
+    const selected = mountainList.find((list: any) => list.명산_이름 === value);
+
+    setSelectedMountain(selected);
+    setKeyword(value);
   };
 
-  useEffect(() => {
-    const debounce = setTimeout(() => {
-      if (keyword) searchData();
-    }, 200);
-    return () => {
-      clearTimeout(debounce);
-    };
-  }, [keyword]);
+  const filteredOptions = options?.filter((option: any) =>
+    option.value.includes(keyword),
+  );
 
   return (
     <>
@@ -194,25 +193,26 @@ export default function ExplorePage() {
         <SearchMountainArea>
           <MainTitle>대한민국 산 탐험하기</MainTitle>
           <SearchContainer>
-            <Search value={keyword} onChange={handleInputChange} />
-            <AutoSearchContainer>
-              <AutoSearchWrap>
-                <AutoSearchData>
-                  {keyItems.map((item: any) => (
-                    <Link href="#" key={item.X좌표}>
-                      {item.명산_이름}
-                    </Link>
-                  ))}
-                </AutoSearchData>
-              </AutoSearchWrap>
-            </AutoSearchContainer>
+            <AutoComplete
+              options={filteredOptions}
+              onSelect={handleSelectMountain}
+              onSearch={handleInputChange}
+              value={keyword}
+            >
+              <Input.Search
+                placeholder="대한민국 산 탐험하기"
+                enterButton
+                onSearch={() => {
+                  console.log('클릭');
+                }}
+              />
+            </AutoComplete>
           </SearchContainer>
-          <SearchTagContainer>
-            <SearchTag>Tag1</SearchTag>
-            <SearchTag>Tag2</SearchTag>
-            <SearchTag>Tag3</SearchTag>
-          </SearchTagContainer>
-          <KakaoMap mountainList={mountainList} />
+
+          <KakaoMap
+            mountainList={mountainList}
+            selectedMountain={selectedMountain}
+          />
         </SearchMountainArea>
 
         <SearchResultArea>

--- a/src/components/explore/ExplorePage.tsx
+++ b/src/components/explore/ExplorePage.tsx
@@ -1,5 +1,6 @@
 'use client';
-import { useState } from 'react';
+
+import { useCallback, useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import styled from 'styled-components';
 import KakaoMap from '@/src/components/explore/KakaoMap';
@@ -7,6 +8,8 @@ import MountainInfo from '@/src/components/shared/MountainInfo';
 import ExploreFilterPanel from '@/src/components/explore/ExploreFilterPanel';
 import getMountainData from '@/src/components/explore/getMountainData';
 import { AutoComplete, Input } from 'antd';
+import { usePathname, useSearchParams, useRouter } from 'next/navigation';
+
 const SearchMountainArea = styled.div`
   margin-top: 7rem;
 `;
@@ -14,20 +17,6 @@ const MainTitle = styled.h2`
   font-size: 3rem;
   font-weight: 600;
   line-height: 4.2rem;
-`;
-
-const SearchTagContainer = styled.div`
-  display: inline-flex;
-  align-items: flex-start;
-  gap: 0.8rem;
-  margin: 2rem 0 4rem 0;
-`;
-
-const SearchTag = styled.span`
-  padding: 0.1rem 0.8rem;
-  border-radius: 0.2rem;
-  border: 1px solid var(--Neutral-5, #d9d9d9);
-  background: var(--Neutral-2, #fafafa);
 `;
 
 const SearchResultArea = styled.div`
@@ -106,57 +95,29 @@ const SearchContainer = styled.div`
   }
 `;
 
-const Search = styled.input`
-  border: 0;
-  padding-left: 10px;
-  background-color: #eaeaea;
-  width: 100%;
-  height: 100%;
-  outline: none;
-`;
-
-const AutoSearchContainer = styled.div`
-  z-index: 3;
-  height: 50vh;
-  width: 400px;
-  background-color: #fff;
-  position: absolute;
-  top: 45px;
-  border: 2px solid;
-  padding: 15px;
-`;
-
-const AutoSearchWrap = styled.ul``;
-
-const AutoSearchData = styled.li`
-  padding: 10px 8px;
-  width: 100%;
-  font-size: 14px;
-  font-weight: bold;
-  z-index: 4;
-  letter-spacing: 2px;
-  &:hover {
-    background-color: #edf5f5;
-    cursor: pointer;
-  }
-  position: relative;
-  img {
-    position: absolute;
-    right: 5px;
-    width: 18px;
-    top: 50%;
-    transform: translateY(-50%);
-  }
-`;
-
 export default function ExplorePage() {
-  const [keyword, setKeyword] = useState<string>('');
-  const [selectedMountain, setSelectedMountain] = useState(null);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const initKeyword = searchParams.get('mountain');
+
+  const [keyword, setKeyword] = useState<string>(initKeyword || '');
+  const [searchedMountain, setSearchedMountain] = useState(null);
 
   const { data: mountainList } = useQuery({
     queryKey: ['mountainList'],
     queryFn: () => getMountainData(),
   });
+
+  const createQueryString = useCallback(
+    (name: string, value: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set(name, value);
+
+      return params.toString();
+    },
+    [searchParams],
+  );
 
   const handleInputChange = (value: string) => {
     setKeyword(value);
@@ -166,16 +127,25 @@ export default function ExplorePage() {
     value: list.명산_이름,
   }));
 
-  const handleSelectMountain = (value: string) => {
-    const selected = mountainList.find((list: any) => list.명산_이름 === value);
-
-    setSelectedMountain(selected);
+  const handleSearch = (value: string) => {
+    // URL 쿼리스트링 업데이트
+    router.push(pathname + '?' + createQueryString('mountain', value));
     setKeyword(value);
   };
 
   const filteredOptions = options?.filter((option: any) =>
     option.value.includes(keyword),
   );
+
+  useEffect(() => {
+    if (initKeyword) {
+      const searched = mountainList?.find(
+        (list: any) => list.명산_이름 === initKeyword,
+      );
+
+      setSearchedMountain(searched);
+    }
+  }, [initKeyword, mountainList]);
 
   return (
     <>
@@ -194,22 +164,24 @@ export default function ExplorePage() {
           <SearchContainer>
             <AutoComplete
               options={filteredOptions}
-              onSelect={handleSelectMountain}
+              onSelect={handleSearch}
               onSearch={handleInputChange}
               value={keyword}
             >
               <Input.Search
                 placeholder="대한민국 산 탐험하기"
+                onSearch={handleSearch}
                 enterButton
-                onSearch={handleSelectMountain}
               />
             </AutoComplete>
           </SearchContainer>
 
-          <KakaoMap
-            mountainList={mountainList}
-            selectedMountain={selectedMountain}
-          />
+          {
+            <KakaoMap
+              mountainList={mountainList}
+              selectedMountain={searchedMountain}
+            />
+          }
         </SearchMountainArea>
 
         <SearchResultArea>
@@ -223,12 +195,25 @@ export default function ExplorePage() {
             </MountainListHeader>
 
             <MountainList>
-              {selectedMountain ? (
-                <MountainInfo list={selectedMountain} />
-              ) : (
+              {initKeyword === '' &&
                 mountainList?.map((list: any) => (
                   <MountainInfo key={list.X좌표} list={list} />
-                ))
+                ))}
+
+              {/* /explore 처음 진입했을떄 */}
+              {!initKeyword &&
+                !searchedMountain &&
+                mountainList?.map((list: any) => (
+                  <MountainInfo key={list.X좌표} list={list} />
+                ))}
+              {/* 검색한 산이 있을때 */}
+              {initKeyword && searchedMountain && (
+                <MountainInfo list={searchedMountain} />
+              )}
+
+              {/* 검색한 산이 없을때 */}
+              {initKeyword && !searchedMountain && (
+                <div>검색 결과가 없습니다.</div>
               )}
             </MountainList>
           </MountainListContainer>

--- a/src/components/explore/HeightFilter.tsx
+++ b/src/components/explore/HeightFilter.tsx
@@ -1,0 +1,75 @@
+import type { CheckboxChangeEvent } from 'antd/lib/checkbox';
+import { Checkbox } from 'antd';
+
+interface HeightFilterProps {
+  heightCheckedList: string[];
+  setHeightCheckedList: (list: string[]) => void;
+}
+const heightOptions = [
+  { label: '500m 미만', range: [0, 500] },
+  { label: '500 ~ 1000m', range: [500, 1000] },
+  { label: '1000 ~ 1500m', range: [1000, 1500] },
+  { label: '1500m 이상', range: [1500, Infinity] },
+];
+
+export default function HeightFilter({
+  heightCheckedList,
+  setHeightCheckedList,
+}: HeightFilterProps) {
+  const handleCheckboxListChange = (
+    option: string,
+    checkedList: string[],
+    setCheckedList: (list: string[]) => void,
+  ) => {
+    const currentIndex = checkedList.indexOf(option);
+    const newCheckedList = [...checkedList];
+
+    if (currentIndex === -1) {
+      newCheckedList.push(option);
+    } else {
+      newCheckedList.splice(currentIndex, 1);
+    }
+
+    setCheckedList(newCheckedList);
+  };
+
+  const handleCheckAllChange = (
+    e: CheckboxChangeEvent,
+    option: string[],
+    setCheckedList: (list: string[]) => void,
+  ) => {
+    setCheckedList(e.target.checked ? option : []);
+  };
+
+  return (
+    <>
+      <Checkbox
+        onChange={(e) =>
+          handleCheckAllChange(
+            e,
+            heightOptions.map((option) => option.label),
+            setHeightCheckedList,
+          )
+        }
+        checked={heightCheckedList.length === heightOptions.length}
+      >
+        전체 선택
+      </Checkbox>
+      {heightOptions.map((option) => (
+        <Checkbox
+          key={option.label}
+          onChange={() =>
+            handleCheckboxListChange(
+              option.label,
+              heightCheckedList,
+              setHeightCheckedList,
+            )
+          }
+          checked={heightCheckedList.includes(option.label)}
+        >
+          {option.label}
+        </Checkbox>
+      ))}
+    </>
+  );
+}

--- a/src/components/explore/KakaoMap.tsx
+++ b/src/components/explore/KakaoMap.tsx
@@ -24,9 +24,8 @@ export default function KakaoMap({
 }) {
   useEffect(() => {
     window.kakao.maps.load(() => {
-      const container = document.getElementById('map'); //지도를 담을 영역의 DOM 레퍼런스
+      const container = document.getElementById('map');
       const options = {
-        //지도를 생성할 때 필요한 기본 옵션
         center: selectedMountain
           ? new window.kakao.maps.LatLng(
               selectedMountain.X좌표,
@@ -36,7 +35,7 @@ export default function KakaoMap({
         level: selectedMountain ? 7 : 13,
       };
 
-      const map = new window.kakao.maps.Map(container, options); //지도 생성 및 객체 리턴
+      const map = new window.kakao.maps.Map(container, options);
 
       const positions = mountainList?.map((list: mountainDataProps) => ({
         title: list.명산_이름,
@@ -48,29 +47,21 @@ export default function KakaoMap({
           : new window.kakao.maps.LatLng(list.X좌표, list.Y좌표),
       }));
 
-      // 마커 이미지의 이미지 주소입니다
       const imageSrc = '/markerSuccess.svg';
 
       for (let i = 0; i < positions?.length; i++) {
-        // 마커 이미지의 이미지 크기 입니다
         const imageSize = new window.kakao.maps.Size(24, 35);
 
-        // 마커 이미지를 생성합니다
         const markerImage = new window.kakao.maps.MarkerImage(
           imageSrc,
           imageSize,
         );
 
-        // 마커를 생성합니다
         const marker = new window.kakao.maps.Marker({
-          map: map, // 마커를 표시할 지도
-          position: positions[i].latlng, // 마커를 표시할 위치
-          title: positions[i].title, // 마커의 타이틀, 마커에 마우스를 올리면 타이틀이 표시됩니다
-          image: markerImage, // 마커 이미지
-        });
-
-        window.kakao.maps.event.addListener(marker, 'click', function () {
-          console.log('클릭됨');
+          map: map,
+          position: positions[i].latlng,
+          title: positions[i].title,
+          image: markerImage,
         });
       }
     });

--- a/src/components/explore/KakaoMap.tsx
+++ b/src/components/explore/KakaoMap.tsx
@@ -17,23 +17,33 @@ interface mountainDataProps {
 
 export default function KakaoMap({
   mountainList,
+  selectedMountain,
 }: {
   mountainList: mountainDataProps[];
+  selectedMountain: any;
 }) {
   useEffect(() => {
     window.kakao.maps.load(() => {
       const container = document.getElementById('map'); //지도를 담을 영역의 DOM 레퍼런스
       const options = {
         //지도를 생성할 때 필요한 기본 옵션
-        center: new window.kakao.maps.LatLng(36.71069, 127.97434), //지도의 중심좌표
-        level: 13, //지도의 레벨(확대, 축소 정도)
+        center: selectedMountain
+          ? new window.kakao.maps.LatLng(
+              selectedMountain?.X좌표,
+              selectedMountain?.Y좌표,
+            )
+          : new window.kakao.maps.LatLng(36.71069, 127.97434),
+        level: selectedMountain ? 7 : 13,
       };
 
       const map = new window.kakao.maps.Map(container, options); //지도 생성 및 객체 리턴
 
       const positions = mountainList?.map((list: mountainDataProps) => ({
         title: list.명산_이름,
-        latlng: new window.kakao.maps.LatLng(list.X좌표, list.Y좌표),
+        latlng: new window.kakao.maps.LatLng(
+          selectedMountain?.X좌표,
+          selectedMountain?.Y좌표,
+        ),
       }));
 
       // 마커 이미지의 이미지 주소입니다
@@ -62,7 +72,7 @@ export default function KakaoMap({
         });
       }
     });
-  }, [mountainList]);
+  }, [mountainList, selectedMountain]);
 
   return <Map id="map" />;
 }

--- a/src/components/explore/KakaoMap.tsx
+++ b/src/components/explore/KakaoMap.tsx
@@ -29,8 +29,8 @@ export default function KakaoMap({
         //지도를 생성할 때 필요한 기본 옵션
         center: selectedMountain
           ? new window.kakao.maps.LatLng(
-              selectedMountain?.X좌표,
-              selectedMountain?.Y좌표,
+              selectedMountain.X좌표,
+              selectedMountain.Y좌표,
             )
           : new window.kakao.maps.LatLng(36.71069, 127.97434),
         level: selectedMountain ? 7 : 13,
@@ -40,10 +40,12 @@ export default function KakaoMap({
 
       const positions = mountainList?.map((list: mountainDataProps) => ({
         title: list.명산_이름,
-        latlng: new window.kakao.maps.LatLng(
-          selectedMountain?.X좌표,
-          selectedMountain?.Y좌표,
-        ),
+        latlng: selectedMountain
+          ? new window.kakao.maps.LatLng(
+              selectedMountain.X좌표,
+              selectedMountain.Y좌표,
+            )
+          : new window.kakao.maps.LatLng(list.X좌표, list.Y좌표),
       }));
 
       // 마커 이미지의 이미지 주소입니다

--- a/src/components/explore/RegionFilter.tsx
+++ b/src/components/explore/RegionFilter.tsx
@@ -1,0 +1,76 @@
+import type { CheckboxChangeEvent } from 'antd/lib/checkbox';
+import { Checkbox } from 'antd';
+
+interface RegionFilterProps {
+  regionCheckedList: string[];
+  setRegionCheckedList: (list: string[]) => void;
+}
+const regionOptions = [
+  '서울',
+  '경기도',
+  '강원도',
+  '충청북도',
+  '충청남도',
+  '전라북도',
+  '전라남도',
+  '경상북도',
+  '경상남도',
+  '제주도',
+];
+
+export default function RegionFilter({
+  regionCheckedList,
+  setRegionCheckedList,
+}: RegionFilterProps) {
+  const handleCheckboxListChange = (
+    option: string,
+    checkedList: string[],
+    setCheckedList: (list: string[]) => void,
+  ) => {
+    const currentIndex = checkedList.indexOf(option);
+    const newCheckedList = [...checkedList];
+
+    if (currentIndex === -1) {
+      newCheckedList.push(option);
+    } else {
+      newCheckedList.splice(currentIndex, 1);
+    }
+
+    setCheckedList(newCheckedList);
+  };
+
+  const handleCheckAllChange = (
+    e: CheckboxChangeEvent,
+    option: string[],
+    setCheckedList: (list: string[]) => void,
+  ) => {
+    setCheckedList(e.target.checked ? option : []);
+  };
+  return (
+    <>
+      <Checkbox
+        onChange={(e) =>
+          handleCheckAllChange(e, regionOptions, setRegionCheckedList)
+        }
+        checked={regionCheckedList.length === regionOptions.length}
+      >
+        전체 선택
+      </Checkbox>
+      {regionOptions.map((option) => (
+        <Checkbox
+          key={option}
+          onChange={() =>
+            handleCheckboxListChange(
+              option,
+              regionCheckedList,
+              setRegionCheckedList,
+            )
+          }
+          checked={regionCheckedList.includes(option)}
+        >
+          {option}
+        </Checkbox>
+      ))}
+    </>
+  );
+}

--- a/src/components/explore/getMountainData.ts
+++ b/src/components/explore/getMountainData.ts
@@ -7,11 +7,9 @@ const DATA_PER_PAGE = 100;
 
 export default async function getMountainData() {
   const url = `${BASE_URL}${END_POINT}?page=${PAGE_NUM}&perPage=${DATA_PER_PAGE}&serviceKey=${process.env.NEXT_PUBLIC_MOUNTAIN_SERVICE_KEY}`;
-  console.log(url);
+
   try {
-    const response = await axios.get(
-      `${BASE_URL}${END_POINT}?page=${PAGE_NUM}&perPage=${DATA_PER_PAGE}&serviceKey=${process.env.NEXT_PUBLIC_MOUNTAIN_SERVICE_KEY}`,
-    );
+    const response = await axios.get(url);
 
     return response.data.data;
   } catch (e) {

--- a/src/components/shared/MountainInfo.tsx
+++ b/src/components/shared/MountainInfo.tsx
@@ -57,10 +57,10 @@ export default function MountainInfo({ list }: any) {
           alt="산 이미지"
         />
         <div>
-          <MountainName>{list.명산_이름}</MountainName>
-          <MountainLocation>{list.명산_소재지}</MountainLocation>
+          <MountainName>{list?.명산_이름}</MountainName>
+          <MountainLocation>{list?.명산_소재지}</MountainLocation>
           <MountainDetail>
-            <MountainHeight>{list.명산_높이}m</MountainHeight>
+            <MountainHeight>{list?.명산_높이}m</MountainHeight>
             <MountainStatus>코스 개수: 15개</MountainStatus>
           </MountainDetail>
         </div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "target": "es2015",
+    "downlevelIteration": true,
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
📌 작업 사항
--- 

- [x] 기능 추가
- [ ] 리팩토링
- [ ] 스타일 수정
- [ ] 에러, 버그 수정
- [ ] 변수명, 함수명, 파일명 변경
- [ ] 폴더, 파일 구조 변경

📌 이슈
--- 

📌 작업 내용
--- 
- 자동완성 검색바 antd autoComplete 를 통해 구현했습니다. (디자인 미구현)
- 산을 검색하면 검색한 산이 지도에 고배율로 표시되고 마찬가지로 검색결과에 해당 산이 나타나도록 하였습니다.
- 메인페이지에서 검색하여 explore 페이지로 접근할 경우를 대비하여 검색 결과가 쿼리 스트링에 반영되어 `explore/?mountain=북한산` 과 같은 식으로 접근하면 북한산이 검색된 explore 페이지가 뜨도록 하였습니다.
- 100대 명산 이외의 검색결과를 입력한 경우 검색 결과가 없다는 메세지가 뜨도록 하였습니다. (디자인 미구현)

📌 테스트결과 / 스크린샷 (선택)
--- 
