### PR TITLE
Chore: tab 컴포넌트, 헤더, 메인페이지 수정

### DIFF
--- a/app/(withHeader)/page.tsx
+++ b/app/(withHeader)/page.tsx
@@ -18,6 +18,10 @@ const Body = styled.div`
   width: 100%;
 `;
 
+const SearchBarContainer = styled.div`
+  padding-top: 5rem;
+`;
+
 const Between = styled.div`
   display: flex;
   justify-content: space-between;
@@ -96,10 +100,9 @@ export default function Home() {
     <>
       <Body>
         <Tab variant="main" />
-        <div>
+        <SearchBarContainer>
           <AutoSearchBar />
-        </div>
-
+        </SearchBarContainer>
         <CarouselSection />
 
         {/* 추후 NavButton 디자인 변경 예정 */}

--- a/app/(withHeader)/page.tsx
+++ b/app/(withHeader)/page.tsx
@@ -15,7 +15,7 @@ const Body = styled.div`
   display: flex;
   flex-direction: column;
   margin-bottom: 10rem;
-  width: 100%;
+  width: 97%;
 `;
 
 const SearchBarContainer = styled.div`

--- a/app/(withHeader)/teams/page.tsx
+++ b/app/(withHeader)/teams/page.tsx
@@ -1,32 +1,25 @@
 'use client';
 
 import styled from 'styled-components';
+import typography from '@/app/styles/typography';
+import Tab from '@/src/components/shared/Tab';
 
-const Container = styled.div``;
+const Title = styled.div`
+  ${typography.Heading30};
+  padding: 1.88rem 0 5rem 0;
 
-const TopSection = styled.div``;
-
-const BottomSection = styled.div`
-  display: grid;
-  grid-template-columns: 1fr 2fr;
-  gap: 2rem;
+  @media (max-width: 768px) {
+    ${typography.Heading24};
+    padding: 1.25rem 0 5rem 0;
+  }
 `;
-
-const FilterSection = styled.div``;
-
-const ListSection = styled.div``;
 
 export default function TeamPage() {
   return (
-    <Container>
-      <TopSection>
-        <div>전체 등산 모임</div>
-        <div>검색 바</div>
-      </TopSection>
-      <BottomSection>
-        <FilterSection>필터</FilterSection>
-        <ListSection>리스트</ListSection>
-      </BottomSection>
-    </Container>
+    <>
+      <Tab variant="teams" />
+      <Title>전체 등산 모임</Title>
+      <div>검색 바</div>
+    </>
   );
 }

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -30,18 +30,19 @@ const IconGap = styled.div`
 `;
 
 // 추후 popover 컴포넌트 edit icon에 연결 필요
-
 export default function Header() {
   return (
     <HeaderBox>
       <LogoContainer>
-        <Image
-          src="/logo.svg"
-          alt="logo icon"
-          width={105.625}
-          height={35.505}
-          priority
-        />
+        <Link href="/" passHref>
+          <Image
+            src="/logo.svg"
+            alt="logo icon"
+            width={105.625}
+            height={35.505}
+            priority
+          />
+        </Link>
       </LogoContainer>
       <IconGap>
         <Image

--- a/src/components/shared/Tab.tsx
+++ b/src/components/shared/Tab.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import typography from '@/app/styles/typography';
 import { colors } from '@/app/styles/colors';
 
@@ -19,10 +19,9 @@ const LinkCol = styled.div`
 const StyledParagraph = styled.p<{ $variant?: Variant }>`
   padding: 1rem 0rem;
 
-  color: ${({ $variant }) =>
-    $variant === 'main' ? colors.Primary[500] : 'inherit'};
+  color: ${({ $variant }) => ($variant ? colors.Primary[500] : 'inherit')};
   border-bottom: ${({ $variant }) =>
-    $variant === 'main' ? `1px solid ${colors.Primary[500]}` : 'none'};
+    $variant ? `1px solid ${colors.Primary[500]}` : 'none'};
 
   &:hover {
     color: ${colors.Primary[500]};
@@ -39,7 +38,9 @@ export default function Tab({ variant }: TabProps) {
     <div>
       <LinkCol>
         <Link href="/" passHref>
-          <StyledParagraph $variant={variant}>추천</StyledParagraph>
+          <StyledParagraph $variant={variant === 'main' ? 'main' : undefined}>
+            추천
+          </StyledParagraph>
         </Link>
         <Link href="/explores" passHref>
           <StyledParagraph

--- a/src/components/shared/Tab.tsx
+++ b/src/components/shared/Tab.tsx
@@ -11,7 +11,6 @@ const LinkCol = styled.div`
   justify-content: start;
   align-items: center;
   color: var(--MDS-GrayScale-13, #000);
-  border-bottom: 1px solid #f0f0f0;
   column-gap: 2.06rem;
   ${typography.Heading20}
 `;


### PR DESCRIPTION
📌 작업 사항
--- 

- [x] 기능 추가
- [ ] 리팩토링
- [x] 스타일 수정
- [ ] 에러, 버그 수정
- [ ] 변수명, 함수명, 파일명 변경
- [ ] 폴더, 파일 구조 변경

📌 이슈
--- 

📌 작업 내용
--- 

tab 컴포넌트의 variant 적용이 main에만 되어있어 수정했습니다. 
Header 내 로고를 누르면 메인페이지로 이동하도록 수정했습니다.
또 오름님이 main페이지에 넣어두신 검색바에 padding을 적용했습니다.

📌 테스트결과 / 스크린샷 (선택)
--- 

[모임 페이지]
![스크린샷 2024-03-25 232536](https://github.com/2-6-collaborative-project/Mounteam/assets/148167964/606994ac-e893-483e-9754-04f8e5462651)

[메인 페이지]
![image](https://github.com/2-6-collaborative-project/Mounteam/assets/148167964/9005299c-e98a-487c-a9b0-ce4819f2787d)

