### PR TITLE
Fix: 산 정보 공용 컴포넌트 현재 api맞게 수정, Chore: 외부 이미지 사용할 수 있게 next.config 수정

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,5 +3,14 @@ const nextConfig = {
   compiler: {
     styledComponents: true,
   },
+
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'www.forest.go.kr',
+      },
+    ],
+  },
 };
 module.exports = nextConfig;

--- a/src/components/shared/MountainInfo.tsx
+++ b/src/components/shared/MountainInfo.tsx
@@ -1,7 +1,8 @@
+'use clinet';
+
 import mountainDataProps from '@/src/types/mountainDataProps';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import styled from 'styled-components';
 
 const MountainItem = styled.div`
@@ -46,16 +47,13 @@ const MountainHeight = styled(MountainStatus)`
   }
 `;
 
-export default function MountainInfo({
-  list,
-}: {
-  list: mountainDataProps | string;
-}) {
+export default function MountainInfo({ list }: { list: mountainDataProps }) {
   let exploreId;
   if (typeof list === 'object') {
-    exploreId = list.X좌표;
+    exploreId = list.exploredId;
   }
 
+  console.log('list', list?.imgUrl);
   return (
     typeof list === 'object' && (
       <Link href={`/explores/${exploreId}/details`}>
@@ -65,15 +63,15 @@ export default function MountainInfo({
             width={260}
             height={260}
             objectFit="contain"
-            src="/sample.jpg"
+            src={list?.imgUrl}
             alt="산 이미지"
           />
           <div>
-            <MountainName>{list?.명산_이름}</MountainName>
-            <MountainLocation>{list?.명산_소재지}</MountainLocation>
+            <MountainName>{list?.mountain}</MountainName>
+            <MountainLocation>{list?.m_location}</MountainLocation>
             <MountainDetail>
-              <MountainHeight>{list?.명산_높이}m</MountainHeight>
-              <MountainStatus>모임 개수: 15개</MountainStatus>
+              <MountainHeight>{list?.m_height}m</MountainHeight>
+              <MountainStatus>모임 개수: {list.teamCnt}</MountainStatus>
             </MountainDetail>
           </div>
         </MountainItem>

--- a/src/types/mountainDataProps.ts
+++ b/src/types/mountainDataProps.ts
@@ -1,7 +1,8 @@
 export default interface mountainDataProps {
-  X좌표: number;
-  Y좌표: number;
-  명산_높이: number;
-  명산_소재지: string;
-  명산_이름: string;
+  exploredId: number;
+  imgUrl: string;
+  m_height: string;
+  m_location: string;
+  mountain: string;
+  teamCnt: number;
 }


### PR DESCRIPTION
📌 작업 사항
--- 

- [ ] 기능 추가
- [ ] 리팩토링
- [ ] 스타일 수정
- [x] 에러, 버그 수정
- [x] 변수명, 함수명, 파일명 변경
- [ ] 폴더, 파일 구조 변경

📌 이슈
--- 

📌 작업 내용
--- 
- 이미지 Url 값이 "https://www.forest.go.kr/kfsweb/cmm/fms/getImage.do?atchFileId=FILE_000000000424398&fileSn=1" 이런식으로 전달돼서 외부 이미지 사용 가능하도록 next.config에 위 이미지의 호스트 등록한 코드 추가됐습니다.
📌 테스트결과 / 스크린샷 (선택)
--- 
