### PR TITLE
feat: 모임 상세 페이지 참가 기능 추가 및 주최자 성별, 프로필 이미지 렌더링 기능 추가

### DIFF
--- a/app/(withHeader)/teams/[teamId]/page.tsx
+++ b/app/(withHeader)/teams/[teamId]/page.tsx
@@ -11,7 +11,7 @@ import { authInstance } from '@/src/lib/axiosInstance';
 import { TEAMS_URL, USER_URL } from '@/src/utils/apiUrl';
 import TeamDetails from '@/src/types/teams/teamDetails';
 import { LoggedInUser } from '@/src/types/auth';
-import AlertModal from '@/src/components/teams/AlertModal';
+import { Modal } from 'antd';
 
 const Container = styled.div`
   margin-top: 8rem;
@@ -252,16 +252,41 @@ export default function TeamDetailsPage() {
     }
   };
 
-  const handleApplyButton = () => {
-    // 로그인된 유저 정보와 참여 조건 비교 로직 추가
-    if (checkApplyCondition() === true) {
-      alert(
-        `오픈카톡방 링크: ${detailsData?.chatLink}\n오픈카톡방 비밀번호: ${detailsData?.chatPassword}`,
-      );
-      return;
-    } else {
-      alert('모임 참여 조건에 맞지 않습니다.');
-      return;
+  const handleApplyButton = async () => {
+    const res = await authInstance.get(`${TEAMS_URL}/${teamId}/join`);
+
+    if (res.status === 200) {
+      if (res.data.statusCode === 200) {
+        Modal.info({
+          title: '오픈 카톡에 입장하여 인사를 나눠보세요.',
+          content: (
+            <div>
+              <br />
+              <p>
+                <span style={{ fontWeight: 'bold' }}>링크: </span>
+                {`${detailsData?.chatLink}`}
+              </p>
+              <br />
+              <p>
+                <span style={{ fontWeight: 'bold' }}>비밀번호: </span>
+                {`${detailsData?.chatPassword}`}
+              </p>
+            </div>
+          ),
+          onOk() {},
+        });
+
+        return;
+      }
+
+      if (res.data.statusCode !== 200) {
+        // alert(`${res.data.msg}`);
+        Modal.error({
+          title: `${res.data.msg}`,
+        });
+
+        return;
+      }
     }
   };
 

--- a/src/components/teams/userProfile.tsx
+++ b/src/components/teams/userProfile.tsx
@@ -65,7 +65,12 @@ export default function UserProfile({
   authorAgeRange,
   areaInterest,
 }: UserProfileProps) {
-  // TODO: 유저 선호 정보 기능 완성 시 데이터 가공 후 렌더링 처리 필요
+  const handleGender = (gender: string) => {
+    if (gender === 'male') {
+      return '남성';
+    } else return '여성';
+  };
+
   const handleAuthorAge = (authorAgeRange: string) => {
     switch (authorAgeRange) {
       case 'teenager':
@@ -86,10 +91,16 @@ export default function UserProfile({
   return (
     <>
       <Container>
-        <Avatar icon={img ? img : <UserOutlined />} size={80} />
+        {img !== null && img !== '' ? (
+          <Avatar src={img} size={80} />
+        ) : (
+          <Avatar icon={<UserOutlined />} size={80} />
+        )}
         <NamePreference>
           <Preferences>
-            {authorGender && <Preference>{authorGender}</Preference>}
+            {authorGender && (
+              <Preference>{handleGender(authorGender)}</Preference>
+            )}
             {authorAgeRange && (
               <Preference>{handleAuthorAge(authorAgeRange)}</Preference>
             )}


### PR DESCRIPTION
📌 작업 사항
--- 

- [x] 기능 추가
- [ ] 리팩토링
- [ ] 스타일 수정
- [ ] 에러, 버그 수정
- [ ] 변수명, 함수명, 파일명 변경
- [ ] 폴더, 파일 구조 변경

📌 이슈
--- 

📌 작업 내용
--- 
- 모임 상세 페이지에서 모임 조건 부합 여부에 따라 다른 modal(오픈 카톡 정보 or 거절)이 발생합니다.
- 모임 상세 페이지 내 주최자의 이미지 및 선호 정보가 표시됩니다.

📌 테스트결과 / 스크린샷 (선택)
--- 
![image](https://github.com/2-6-collaborative-project/Mounteam/assets/97048179/438257fc-52be-4cd2-ae4e-a86b148c50ac)

![image](https://github.com/2-6-collaborative-project/Mounteam/assets/97048179/430e62c6-2464-485b-8431-5b4ccaa3f796)
