### PR TITLE
Feat: 탐험 페이지 정렬 기능 api 연동

### DIFF
--- a/src/components/explores/api/getMountainList.ts
+++ b/src/components/explores/api/getMountainList.ts
@@ -1,16 +1,19 @@
 import { defaultInstance } from '@/src/lib/axiosInstance';
+import { EXPLORE_URL } from '@/src/utils/apiUrl';
 
 const getMountainList = async (
   page: null | number,
   size: number,
+  orderBy?: 'popular' | 'name',
   cursor?: number,
 ) => {
   try {
-    const response = await defaultInstance.get('/explores', {
+    const response = await defaultInstance.get(`${EXPLORE_URL}`, {
       params: {
-        cursor,
         page,
         size,
+        orderBy,
+        cursor,
         sort: '',
       },
     });

--- a/src/components/shared/MountainInfo.tsx
+++ b/src/components/shared/MountainInfo.tsx
@@ -92,7 +92,6 @@ export default function MountainInfo({
             <Image
               width={300}
               height={300}
-              objectFit="cover"
               src={list?.imageUrls}
               alt="산 이미지"
             />

--- a/src/utils/CheckValidAuth.ts
+++ b/src/utils/CheckValidAuth.ts
@@ -21,16 +21,12 @@ export default function CheckValidAuth() {
           const res = await authInstance.get('/user/profile');
           return true;
         } else {
-          const confirmResult = window.confirm(
-            '토큰이 만료되어 로그인 페이지로 이동합니다. 다시 로그인 해주세요.',
-          );
+          const confirmResult = window.confirm('로그인 후 이용해 주세요.');
 
           if (confirmResult) return router.push('/signin');
         }
       } catch (e) {
-        const confirmResult = window.confirm(
-          '토큰이 만료되어 로그인 페이지로 이동합니다. 다시 로그인 해주세요.',
-        );
+        const confirmResult = window.confirm('로그인 후 이용해 주세요.');
         if (confirmResult) return router.push('/signin');
       }
     };

--- a/src/utils/apiUrl.ts
+++ b/src/utils/apiUrl.ts
@@ -3,3 +3,5 @@ export const BASE_URL = 'https://api.mounteam.site/api';
 export const TEAMS_URL = '/teams';
 
 export const USER_URL = '/user';
+
+export const EXPLORE_URL = '/explores';


### PR DESCRIPTION
📌 작업 사항
--- 

- [x] 기능 추가
- [x] 리팩토링
- [ ] 스타일 수정
- [ ] 에러, 버그 수정
- [ ] 변수명, 함수명, 파일명 변경
- [ ] 폴더, 파일 구조 변경

📌 이슈
--- 
- 무한스크롤을 유지하면서 정렬 api를 호출하게 되면 데이터가 중복으로 나타나는 이슈가 발생
(ex. 인기순으로 정렬시 관악산이 첫번째로 렌더링 되면 무한 스크롤 진행 중 열 번째에 관악산이 또 한번 렌더링됨)
- 방법을 찾지 못해서 스웨거에서 동작하는대로 정렬된 데이터를 받아와서 렌더링 하는 방식으로 설정 -> 모든 데이터에 대해 정렬된 데이터가 오므로 무한스크롤 적용 x

📌 작업 내용
--- 


📌 테스트결과 / 스크린샷 (선택)
--- 
