### PR TITLE
Fix: 모임 컴포넌트 대표이미지 정렬 수정

### DIFF
--- a/src/components/shared/TeamThumbnail.tsx
+++ b/src/components/shared/TeamThumbnail.tsx
@@ -50,6 +50,8 @@ const ImageSection = styled.div`
   color: ${colors.Grayscale[1]};
   font-size: 1.6rem;
   line-height: 1.75rem;
+  text-align: center;
+  white-space: pre-line;
 
   @media (max-width: 768px) {
     width: 7.5rem;
@@ -140,6 +142,16 @@ const TeamRange = styled.div`
   text-align: center;
   ${typography.Footnote14};
 `;
+
+const formatMountainName = (name: string) => {
+  const bracketIndex = name.indexOf('(');
+  if (bracketIndex !== -1) {
+    return `${name.substring(0, bracketIndex)}\n${name.substring(bracketIndex)}`;
+  } else if (name.length === 4) {
+    return `${name.substring(0, 2)}\n${name.substring(2)}`;
+  }
+  return name;
+};
 
 export default function TeamThumbnail({ team }: { team: TeamFeedType }) {
   const router = useRouter();
@@ -232,7 +244,9 @@ export default function TeamThumbnail({ team }: { team: TeamFeedType }) {
 
   return (
     <TeamBox onClick={handleClick}>
-      <ImageSection className={IBM.className}>{team.mountain}</ImageSection>
+      <ImageSection className={IBM.className}>
+        {formatMountainName(team.mountain)}
+      </ImageSection>
       <TeamCol>
         <TeamInfo>
           <Title>{truncateTitle(team.title)}</Title>


### PR DESCRIPTION
📌 작업 사항
--- 

- [ ] 기능 추가
- [ ] 리팩토링
- [x] 스타일 수정
- [ ] 에러, 버그 수정
- [ ] 변수명, 함수명, 파일명 변경
- [ ] 폴더, 파일 구조 변경


📌 작업 내용
--- 
산이름이 표시되는 이미지 부분의 정렬을 수정했습니다.

📌 테스트결과 / 스크린샷 (선택)
--- 
![스크린샷 2024-05-12 162534](https://github.com/2-6-collaborative-project/Mounteam/assets/148167964/36dad3d4-cdbd-42b2-9ed5-229d16676ac7)



